### PR TITLE
Fix DMux8way Body

### DIFF
--- a/snippets/hdl.code-snippets
+++ b/snippets/hdl.code-snippets
@@ -104,7 +104,7 @@
       "DMux8Way"
     ],
     "body": [
-      "DMux4Way(in=$1, sel=$2, a=$3, b=$4, c=$5, d=$6, e=$7, f=$8, g=$9, h=$10);",
+      "DMux8Way(in=$1, sel=$2, a=$3, b=$4, c=$5, d=$6, e=$7, f=$8, g=$9, h=$10);",
       "$0"
     ],
     "description": "/* Channels the input to one out of eight outputs */"


### PR DESCRIPTION
Allow the snippet to write "Dmux8way" instead of current "Dmux4way" when choosing the "DMux8way" chip